### PR TITLE
Remove HHVM 4.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: generic
 services: docker
 env:
-- HHVM_VERSION=4.6-latest
 - HHVM_VERSION=4.8-latest
 - HHVM_VERSION=latest
 - HHVM_VERSION=nightly


### PR DESCRIPTION
Travis fails because of a dependency of that version. HHVM 4.6 isn't supported anyhow.